### PR TITLE
feat: cadastro de novo professores

### DIFF
--- a/src/common/decorators/upload-image.decorator.ts
+++ b/src/common/decorators/upload-image.decorator.ts
@@ -9,6 +9,9 @@ export function UploadImage(): MethodDecorator {
   return applyDecorators(
     UseInterceptors(
       FileInterceptor('image', {
+        limits: {
+          fileSize: 5 * 1024 * 1024,
+        },
         fileFilter: (req, file, cb) => {
           if (!file.mimetype.match(/\/(jpg|jpeg|png|gif)$/)) {
             return cb(

--- a/src/common/services/services.module.ts
+++ b/src/common/services/services.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 
 import { LoggerService } from './logger/logger.service';
+import { ValidateFieldsService } from './validate-fields/validate-fields.service';
 
 @Module({
-  providers: [LoggerService],
+  providers: [LoggerService, ValidateFieldsService],
+  exports: [ValidateFieldsService],
 })
 export class ServicesModule {}

--- a/src/common/services/validate-fields/validate-fields.service.spec.ts
+++ b/src/common/services/validate-fields/validate-fields.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ValidateFieldsService } from './validate-fields.service';
+
+describe('ValidateFieldsService', () => {
+  let service: ValidateFieldsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ValidateFieldsService],
+    }).compile();
+
+    service = module.get<ValidateFieldsService>(ValidateFieldsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/common/services/validate-fields/validate-fields.service.spec.ts
+++ b/src/common/services/validate-fields/validate-fields.service.spec.ts
@@ -1,19 +1,138 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Connection, Types } from 'mongoose';
+import { getConnectionToken } from '@nestjs/mongoose';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 
 import { ValidateFieldsService } from './validate-fields.service';
 
 describe('ValidateFieldsService', () => {
   let service: ValidateFieldsService;
+  let connection: Connection;
+
+  const modelMock = {
+    exists: jest.fn(),
+    findById: jest.fn().mockReturnThis(),
+    lean: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ValidateFieldsService],
+      providers: [
+        ValidateFieldsService,
+        {
+          provide: getConnectionToken(),
+          useValue: {
+            model: jest.fn().mockReturnValue(modelMock),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<ValidateFieldsService>(ValidateFieldsService);
+    connection = module.get<Connection>(getConnectionToken());
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should not throw exception if email does not exist', async () => {
+    modelMock.exists.mockResolvedValueOnce(null);
+
+    await expect(
+      service.validateEmail('User', 'test@email.com'),
+    ).resolves.toBeUndefined();
+
+    expect(connection.model).toHaveBeenCalledWith('User');
+    expect(modelMock.exists).toHaveBeenCalledWith({ email: 'test@email.com' });
+  });
+
+  it('should throw ConflictException if email already exists', async () => {
+    modelMock.exists.mockResolvedValueOnce(true);
+
+    await expect(
+      service.validateEmail('User', 'test@email.com'),
+    ).rejects.toThrow(
+      new ConflictException(`Email test@email.com already exists`),
+    );
+
+    expect(connection.model).toHaveBeenCalledWith('User');
+    expect(modelMock.exists).toHaveBeenCalledWith({ email: 'test@email.com' });
+  });
+
+  it('should not throw exception if cpf does not exist', async () => {
+    modelMock.exists.mockResolvedValueOnce(null);
+
+    await expect(
+      service.validateCpf('User', '12345678910'),
+    ).resolves.toBeUndefined();
+
+    expect(connection.model).toHaveBeenCalledWith('User');
+    expect(modelMock.exists).toHaveBeenCalledWith({ cpf: '12345678910' });
+  });
+
+  it('should throw ConflictException if cpf already exists', async () => {
+    modelMock.exists.mockResolvedValueOnce(true);
+
+    await expect(service.validateCpf('User', '12345678910')).rejects.toThrow(
+      new ConflictException(`CPF 12345678910 already exists`),
+    );
+
+    expect(connection.model).toHaveBeenCalledWith('User');
+    expect(modelMock.exists).toHaveBeenCalledWith({ cpf: '12345678910' });
+  });
+
+  it('should not throw exception if document is active', async () => {
+    const document = {
+      _id: new Types.ObjectId('64f1b2a3c4d5e6f7890abc12'),
+      status: true,
+    };
+
+    modelMock.findById.mockReturnThis();
+    modelMock.lean.mockResolvedValue(document);
+
+    await expect(
+      service.isActive('User', document._id),
+    ).resolves.toBeUndefined();
+
+    expect(connection.model).toHaveBeenCalledWith('User');
+    expect(modelMock.findById).toHaveBeenCalledWith(document._id);
+  });
+
+  it('should throw NotFoundException if document is not found', async () => {
+    const id = new Types.ObjectId('64f1b2a3c4d5e6f7890abc12');
+
+    modelMock.findById.mockReturnThis();
+    modelMock.lean.mockResolvedValue(null);
+
+    await expect(service.isActive('User', id)).rejects.toThrow(
+      new NotFoundException(`User with id ${id} not found`),
+    );
+
+    expect(connection.model).toHaveBeenCalledWith('User');
+    expect(modelMock.findById).toHaveBeenCalledWith(id);
+  });
+
+  it('should throw BadRequestException if document is disable', async () => {
+    const document = {
+      _id: new Types.ObjectId('64f1b2a3c4d5e6f7890abc12'),
+      status: false,
+    };
+
+    modelMock.findById.mockReturnThis();
+    modelMock.lean.mockResolvedValue(document);
+
+    await expect(service.isActive('User', document._id)).rejects.toThrow(
+      new BadRequestException(`User with id ${document._id} is disabled`),
+    );
+
+    expect(connection.model).toHaveBeenCalledWith('User');
+    expect(modelMock.findById).toHaveBeenCalledWith(document._id);
   });
 });

--- a/src/common/services/validate-fields/validate-fields.service.ts
+++ b/src/common/services/validate-fields/validate-fields.service.ts
@@ -1,4 +1,9 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectConnection } from '@nestjs/mongoose';
 import { Connection } from 'mongoose';
 
@@ -23,6 +28,20 @@ export class ValidateFieldsService {
 
     if (cpfExists) {
       throw new ConflictException(`CPF ${cpf} already exists`);
+    }
+  }
+
+  public async isActive(modelName: string, id: string): Promise<void> {
+    const model = this.connection.model(modelName);
+
+    const document = await model.findById(id).lean<{ status: boolean }>();
+
+    if (!document) {
+      throw new NotFoundException(`${modelName} with id ${id} not found`);
+    }
+
+    if (!document.status) {
+      throw new BadRequestException(`${modelName} with id ${id} is disabled`);
     }
   }
 }

--- a/src/common/services/validate-fields/validate-fields.service.ts
+++ b/src/common/services/validate-fields/validate-fields.service.ts
@@ -15,4 +15,14 @@ export class ValidateFieldsService {
       throw new ConflictException(`Email ${email} already exists`);
     }
   }
+
+  public async validateCpf(modelName: string, cpf: string): Promise<void> {
+    const model = this.connection.model(modelName);
+
+    const cpfExists = await model.exists({ cpf });
+
+    if (cpfExists) {
+      throw new ConflictException(`CPF ${cpf} already exists`);
+    }
+  }
 }

--- a/src/common/services/validate-fields/validate-fields.service.ts
+++ b/src/common/services/validate-fields/validate-fields.service.ts
@@ -1,0 +1,18 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectConnection } from '@nestjs/mongoose';
+import { Connection } from 'mongoose';
+
+@Injectable()
+export class ValidateFieldsService {
+  constructor(@InjectConnection() private readonly connection: Connection) {}
+
+  public async validateEmail(modelName: string, email: string): Promise<void> {
+    const model = this.connection.model(modelName);
+
+    const emailExists = await model.exists({ email });
+
+    if (emailExists) {
+      throw new ConflictException(`Email ${email} already exists`);
+    }
+  }
+}

--- a/src/common/services/validate-fields/validate-fields.service.ts
+++ b/src/common/services/validate-fields/validate-fields.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/mongoose';
-import { Connection } from 'mongoose';
+import { Connection, Types } from 'mongoose';
 
 @Injectable()
 export class ValidateFieldsService {
@@ -31,7 +31,7 @@ export class ValidateFieldsService {
     }
   }
 
-  public async isActive(modelName: string, id: string): Promise<void> {
+  public async isActive(modelName: string, id: Types.ObjectId): Promise<void> {
     const model = this.connection.model(modelName);
 
     const document = await model.findById(id).lean<{ status: boolean }>();

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -6,11 +6,13 @@ import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 
 import { AuthModule } from '@ds-modules/auth/auth.module';
+import { ServicesModule } from '@ds-services/services.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: 'Admin', schema: AdminSchema }]),
     AuthModule,
+    ServicesModule,
   ],
   controllers: [AdminController],
   providers: [AdminService],

--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -15,22 +15,18 @@ import { FindAdminDto } from './dtos/find-admin.dto';
 import { UpdateAdminDto } from './dtos/update-admin.dto';
 
 import { AdminDocument } from '@ds-types/documents/admin';
+import { ValidateFieldsService } from '@ds-services/validate-fields/validate-fields.service';
 
 @Injectable()
 export class AdminService {
   constructor(
     @InjectModel(Admin.name) private adminModel: Model<Admin>,
     private jwtService: JwtService,
+    private readonly validadeFieldsService: ValidateFieldsService,
   ) {}
 
   public async createAdmin(adminDto: AdminDto): Promise<AdminDocument> {
-    const admin = await this.adminModel
-      .findOne({ email: adminDto.email })
-      .exec();
-
-    if (admin) {
-      throw new ConflictException('An admin with this email already exists');
-    }
+    await this.validadeFieldsService.validateEmail('Admin', adminDto.email);
 
     return await this.adminModel.create(adminDto);
   }

--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -22,11 +22,11 @@ export class AdminService {
   constructor(
     @InjectModel(Admin.name) private adminModel: Model<Admin>,
     private jwtService: JwtService,
-    private readonly validadeFieldsService: ValidateFieldsService,
+    private readonly validateFieldsService: ValidateFieldsService,
   ) {}
 
   public async createAdmin(adminDto: AdminDto): Promise<AdminDocument> {
-    await this.validadeFieldsService.validateEmail('Admin', adminDto.email);
+    await this.validateFieldsService.validateEmail('Admin', adminDto.email);
 
     return await this.adminModel.create(adminDto);
   }

--- a/src/modules/modalities/modalities.module.ts
+++ b/src/modules/modalities/modalities.module.ts
@@ -15,6 +15,6 @@ import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe
   ],
   controllers: [ModalitiesController],
   providers: [ModalitiesService, ReduceImagePipe],
-  exports: [ModalitiesService],
+  exports: [],
 })
 export class ModalitiesModule {}

--- a/src/modules/plans/dtos/plan.dto.ts
+++ b/src/modules/plans/dtos/plan.dto.ts
@@ -1,6 +1,7 @@
 import { IsEnum, IsMongoId, IsNumber, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
+import { Types } from 'mongoose';
 
 import { Period } from '@ds-enums/period.enum';
 
@@ -35,5 +36,5 @@ export class PlanDto {
     example: '64f1b2a3c4d5e6f7890abc12',
   })
   @IsMongoId()
-  modality: string;
+  modality: Types.ObjectId;
 }

--- a/src/modules/plans/dtos/plan.dto.ts
+++ b/src/modules/plans/dtos/plan.dto.ts
@@ -1,5 +1,6 @@
-import { IsEnum, IsMongoId, IsNumber } from 'class-validator';
+import { IsEnum, IsMongoId, IsNumber, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 
 import { Period } from '@ds-enums/period.enum';
 
@@ -15,14 +16,18 @@ export class PlanDto {
     description: 'Quantidade do período definido em period',
     example: '3',
   })
+  @Transform(({ value }) => parseInt(value))
   @IsNumber()
+  @Min(1)
   periodQuantity: number;
 
   @ApiProperty({
     description: 'Preço do plano',
     example: '150.00',
   })
+  @Transform(({ value }) => parseInt(value))
   @IsNumber()
+  @Min(1)
   value: number;
 
   @ApiProperty({

--- a/src/modules/plans/plans.controller.spec.ts
+++ b/src/modules/plans/plans.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
+import { Types } from 'mongoose';
 
 import { PlansController } from './plans.controller';
 import { PlansService } from './plans.service';
@@ -42,7 +43,7 @@ describe('PlansController', () => {
       period: Period.MONTHLY,
       periodQuantity: 3,
       value: 150,
-      modality: '64f1b2a3c4d5e6f7890abc12',
+      modality: new Types.ObjectId('64f1b2a3c4d5e6f7890abc12'),
     };
     const plan = {
       period: Period.MONTHLY,

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -5,12 +5,12 @@ import { PlansSchema } from './schemas/plans.schema';
 import { PlansService } from './plans.service';
 import { PlansController } from './plans.controller';
 
-import { ModalitiesModule } from '@ds-modules/modalities/modalities.module';
+import { ServicesModule } from '@ds-services/services.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: 'Plans', schema: PlansSchema }]),
-    ModalitiesModule,
+    ServicesModule,
   ],
   providers: [PlansService],
   controllers: [PlansController],

--- a/src/modules/plans/plans.service.ts
+++ b/src/modules/plans/plans.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
@@ -10,27 +6,18 @@ import { Plans } from './schemas/plans.schema';
 import { PlanDto } from './dtos/plan.dto';
 import { FindPlansDto } from './dtos/find-plans.dto';
 
-import { ModalitiesService } from '@ds-modules/modalities/modalities.service';
 import { PlanDocument } from '@ds-types/documents/plan-document';
-import { ModalitiesDocument } from '@ds-types/documents/modalitie-document.type';
+import { ValidateFieldsService } from '@ds-services/validate-fields/validate-fields.service';
 
 @Injectable()
 export class PlansService {
   constructor(
     @InjectModel(Plans.name) private plansModel: Model<Plans>,
-    private readonly modalitiesService: ModalitiesService,
+    private readonly validateFieldsService: ValidateFieldsService,
   ) {}
 
   public async createPlan(planDto: PlanDto): Promise<PlanDocument> {
-    const modality: ModalitiesDocument = await this.modalitiesService.findById(
-      planDto.modality,
-    );
-
-    if (!modality.status) {
-      throw new BadRequestException(
-        `Modality with id ${planDto.modality} is disabled`,
-      );
-    }
+    await this.validateFieldsService.isActive('Modalities', planDto.modality);
 
     const newPlan = await this.plansModel.create(planDto);
 

--- a/src/modules/teachers/dtos/teacher.dto.ts
+++ b/src/modules/teachers/dtos/teacher.dto.ts
@@ -1,0 +1,34 @@
+import { Transform } from 'class-transformer';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsEmail,
+  IsMongoId,
+  IsNumber,
+  IsString,
+  Length,
+  Min,
+} from 'class-validator';
+import { Types } from 'mongoose';
+
+export class TeacherDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  @Length(11, 11)
+  cpf: string;
+
+  @IsEmail()
+  email: string;
+
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(1)
+  hourPrice: number;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsMongoId({ each: true })
+  modalities: Types.ObjectId[];
+}

--- a/src/modules/teachers/dtos/teacher.dto.ts
+++ b/src/modules/teachers/dtos/teacher.dto.ts
@@ -27,6 +27,9 @@ export class TeacherDto {
   @Min(1)
   hourPrice: number;
 
+  @IsString()
+  description: string;
+
   @IsArray()
   @ArrayNotEmpty()
   @IsMongoId({ each: true })

--- a/src/modules/teachers/schemas/teachers.schema.ts
+++ b/src/modules/teachers/schemas/teachers.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Types } from 'mongoose';
+import { Query, Types } from 'mongoose';
 
 import { Modalities } from '@ds-modules/modalities/schemas/modalities.schema';
 
@@ -24,6 +24,9 @@ export class Teachers {
   })
   email: string;
 
+  @Prop({ required: [true, 'A teacher must have a description'], type: String })
+  description: string;
+
   @Prop({ required: [true, 'A teacher must have a image'], type: Buffer })
   image: Buffer;
 
@@ -47,3 +50,12 @@ export class Teachers {
 }
 
 export const TeachersSchema = SchemaFactory.createForClass(Teachers);
+
+TeachersSchema.pre<Query<Teachers[], Teachers>>(/^find/, function (next) {
+  this.populate({
+    path: 'modalities',
+    select: '-createdAt -updatedAt -image',
+  });
+
+  next();
+});

--- a/src/modules/teachers/schemas/teachers.schema.ts
+++ b/src/modules/teachers/schemas/teachers.schema.ts
@@ -24,8 +24,8 @@ export class Teachers {
   })
   email: string;
 
-  @Prop({ required: [true, 'A teacher must have a photo'], type: String })
-  photo: string;
+  @Prop({ required: [true, 'A teacher must have a image'], type: Buffer })
+  image: Buffer;
 
   @Prop({ required: [true, 'A teacher must have a hour price'], type: Number })
   hourPrice: number;

--- a/src/modules/teachers/teachers.controller.spec.ts
+++ b/src/modules/teachers/teachers.controller.spec.ts
@@ -1,19 +1,90 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Types } from 'mongoose';
 
 import { TeachersController } from './teachers.controller';
+import { TeachersService } from './teachers.service';
+import { TeacherDto } from './dtos/teacher.dto';
+
+import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
 
 describe('TeachersController', () => {
   let controller: TeachersController;
+  let teachersService: TeachersService;
+  let reduceImagePipe: jest.Mocked<ReduceImagePipe>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TeachersController],
+      providers: [
+        {
+          provide: TeachersService,
+          useValue: {
+            createTeacher: jest.fn(),
+          },
+        },
+        {
+          provide: ReduceImagePipe,
+          useValue: {
+            transform: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<TeachersController>(TeachersController);
+    teachersService = module.get<TeachersService>(TeachersService);
+    reduceImagePipe = module.get<jest.Mocked<ReduceImagePipe>>(ReduceImagePipe);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should create a teacher sucessfuly', async () => {
+    const dto: TeacherDto = {
+      name: 'Test',
+      cpf: '12345678910',
+      email: 'test@gmail.com',
+      hourPrice: 5,
+      description: 'Unit tests with jest',
+      modalities: [
+        new Types.ObjectId('64f1b2a3c4d5e6f7890abc12'),
+        new Types.ObjectId('64f1b2a3c4d5e6f7890abc34'),
+      ],
+    };
+    const mockFile = {
+      buffer: Buffer.from('fake-image'),
+      mimetype: 'image/png',
+    } as Express.Multer.File;
+    const reducedImage = Buffer.from('reduced-image');
+    const teacher = {
+      _id: new Types.ObjectId('64f1b2a3c4d5e6f7890abc15'),
+      ...dto,
+      modalities: [
+        {
+          name: 'Judô',
+          description: 'Modalidade Judô',
+        },
+        {
+          name: 'Jiu-Jitsu',
+          description: 'Modalidade Jiu-Jitsu',
+        },
+      ],
+      image: reducedImage,
+    };
+
+    reduceImagePipe.transform.mockResolvedValue(reducedImage);
+    teachersService.createTeacher = jest.fn().mockResolvedValue(teacher);
+
+    const result = await controller.createTeacher(mockFile, dto);
+
+    expect(result).toEqual({ data: teacher });
+    expect(reduceImagePipe.transform).toHaveBeenCalledWith(mockFile);
+    expect(teachersService.createTeacher).toHaveBeenCalledWith({
+      ...dto,
+      image: reducedImage,
+    });
   });
 });

--- a/src/modules/teachers/teachers.controller.spec.ts
+++ b/src/modules/teachers/teachers.controller.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TeachersController } from './teachers.controller';
+
+describe('TeachersController', () => {
+  let controller: TeachersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TeachersController],
+    }).compile();
+
+    controller = module.get<TeachersController>(TeachersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -1,4 +1,10 @@
-import { Body, Controller, Post, UploadedFile } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
 
 import { TeachersService } from './teachers.service';
 import { TeacherDto } from './dtos/teacher.dto';
@@ -6,7 +12,10 @@ import { TeacherDto } from './dtos/teacher.dto';
 import { UploadImage } from '@ds-common/decorators/upload-image.decorator';
 import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
 import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
+import { ImageBase64Interceptor } from '@ds-common/interceptors/image-base64/image-base64.interceptor';
+import { ApiResponse } from '@ds-types/api-response.type';
 
+@UseInterceptors(ImageBase64Interceptor)
 @Controller('teachers')
 export class TeachersController {
   constructor(
@@ -19,12 +28,18 @@ export class TeachersController {
   public async createTeacher(
     @UploadedFile() file: Express.Multer.File,
     @Body() teacherDto: TeacherDto,
-  ) {
+  ): Promise<ApiResponse<TeacherDocument>> {
     const reducedImageBuffer = await this.reduceImagePipe.transform(file);
 
     const newTeacher = {
       ...teacherDto,
       image: reducedImageBuffer,
     } as TeacherDocument;
+
+    const teacher = await this.teachersService.createTeacher(newTeacher);
+
+    return {
+      data: teacher,
+    };
   }
 }

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -3,8 +3,11 @@ import {
   Controller,
   Post,
   UploadedFile,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { AuthGuard } from '@nestjs/passport';
 
 import { TeachersService } from './teachers.service';
 import { TeacherDto } from './dtos/teacher.dto';
@@ -14,6 +17,8 @@ import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe
 import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
 import { ImageBase64Interceptor } from '@ds-common/interceptors/image-base64/image-base64.interceptor';
 import { ApiResponse } from '@ds-types/api-response.type';
+import { Roles } from '@ds-common/decorators/roles.decorator';
+import { RoleGuard } from '@ds-common/guards/role/role.guard';
 
 @UseInterceptors(ImageBase64Interceptor)
 @Controller('teachers')
@@ -23,6 +28,14 @@ export class TeachersController {
     private readonly reduceImagePipe: ReduceImagePipe,
   ) {}
 
+  @UseGuards(AuthGuard('jwt'), RoleGuard)
+  @Roles('admin')
+  @Throttle({
+    default: {
+      limit: 5,
+      ttl: 60000,
+    },
+  })
   @UploadImage()
   @Post()
   public async createTeacher(

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@nestjs/common';
+
+import { TeachersService } from './teachers.service';
+
+@Controller('teachers')
+export class TeachersController {
+  constructor(private readonly teachersService: TeachersService) {}
+}

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -1,8 +1,30 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post, UploadedFile } from '@nestjs/common';
 
 import { TeachersService } from './teachers.service';
+import { TeacherDto } from './dtos/teacher.dto';
+
+import { UploadImage } from '@ds-common/decorators/upload-image.decorator';
+import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
+import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
 
 @Controller('teachers')
 export class TeachersController {
-  constructor(private readonly teachersService: TeachersService) {}
+  constructor(
+    private readonly teachersService: TeachersService,
+    private readonly reduceImagePipe: ReduceImagePipe,
+  ) {}
+
+  @UploadImage()
+  @Post()
+  public async createTeacher(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() teacherDto: TeacherDto,
+  ) {
+    const reducedImageBuffer = await this.reduceImagePipe.transform(file);
+
+    const newTeacher = {
+      ...teacherDto,
+      image: reducedImageBuffer,
+    } as TeacherDocument;
+  }
 }

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -8,6 +8,12 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { AuthGuard } from '@nestjs/passport';
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiCookieAuth,
+  ApiOperation,
+} from '@nestjs/swagger';
 
 import { TeachersService } from './teachers.service';
 import { TeacherDto } from './dtos/teacher.dto';
@@ -28,6 +34,67 @@ export class TeachersController {
     private readonly reduceImagePipe: ReduceImagePipe,
   ) {}
 
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: 'Cadastra um novo professor',
+    description:
+      'Apenas usuários com token jwt e cargos "admin" podem utilizar este endpoint',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Nome do professor',
+          example: 'Marcos Silva',
+        },
+        cpf: {
+          type: 'string',
+          description: 'CPF do professor (apenas números)',
+          example: '12345678910',
+        },
+        email: {
+          type: 'string',
+          description: 'Email do professor',
+          example: 'marcossilva@gmail.com',
+        },
+        hourPrice: {
+          type: 'number',
+          description: 'Valor da hora/aula do professor',
+          example: '5.0',
+        },
+        description: {
+          type: 'string',
+          description: 'Descrição da modalidade',
+          example: `Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.`,
+        },
+        modalities: {
+          type: 'array',
+          description: 'IDs das modalidades (ObjectId do MongoDB)',
+          items: {
+            type: 'string',
+            example: '64f1b2a3c4d5e6f7890abc12',
+          },
+        },
+        image: {
+          type: 'string',
+          format: 'binary',
+          description: 'Imagem da modalidade (jpg, jpeg, png, gif)',
+        },
+      },
+      required: [
+        'name',
+        'cpf',
+        'email',
+        'hourPrice',
+        'description',
+        'modalities',
+        'image',
+      ],
+    },
+  })
+  @ApiConsumes('multipart/form-data')
   @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Roles('admin')
   @Throttle({

--- a/src/modules/teachers/teachers.module.ts
+++ b/src/modules/teachers/teachers.module.ts
@@ -6,6 +6,7 @@ import { TeachersController } from './teachers.controller';
 import { TeachersService } from './teachers.service';
 
 import { ModalitiesModule } from '@ds-modules/modalities/modalities.module';
+import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
 
 @Module({
   imports: [
@@ -13,6 +14,6 @@ import { ModalitiesModule } from '@ds-modules/modalities/modalities.module';
     ModalitiesModule,
   ],
   controllers: [TeachersController],
-  providers: [TeachersService],
+  providers: [TeachersService, ReduceImagePipe],
 })
 export class TeachersModule {}

--- a/src/modules/teachers/teachers.module.ts
+++ b/src/modules/teachers/teachers.module.ts
@@ -2,10 +2,17 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { TeachersSchema } from './schemas/teachers.schema';
+import { TeachersController } from './teachers.controller';
+import { TeachersService } from './teachers.service';
+
+import { ModalitiesModule } from '@ds-modules/modalities/modalities.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: 'Teachers', schema: TeachersSchema }]),
+    ModalitiesModule,
   ],
+  controllers: [TeachersController],
+  providers: [TeachersService],
 })
 export class TeachersModule {}

--- a/src/modules/teachers/teachers.module.ts
+++ b/src/modules/teachers/teachers.module.ts
@@ -7,11 +7,13 @@ import { TeachersService } from './teachers.service';
 
 import { ModalitiesModule } from '@ds-modules/modalities/modalities.module';
 import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
+import { ServicesModule } from '@ds-services/services.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: 'Teachers', schema: TeachersSchema }]),
     ModalitiesModule,
+    ServicesModule,
   ],
   controllers: [TeachersController],
   providers: [TeachersService, ReduceImagePipe],

--- a/src/modules/teachers/teachers.service.spec.ts
+++ b/src/modules/teachers/teachers.service.spec.ts
@@ -1,19 +1,134 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Model, Types } from 'mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 
 import { TeachersService } from './teachers.service';
+import { Teachers } from './schemas/teachers.schema';
+
+import { ValidateFieldsService } from '@ds-services/validate-fields/validate-fields.service';
+import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
 
 describe('TeachersService', () => {
   let service: TeachersService;
+  let validateFieldsService: ValidateFieldsService;
+
+  let model: Model<TeacherDocument>;
+
+  const mockTeacherModel = {
+    findOne: jest.fn().mockReturnThis(),
+    findById: jest.fn().mockReturnThis(),
+    find: jest.fn().mockReturnThis(),
+    findByIdAndUpdate: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    equals: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    exec: jest.fn(),
+    create: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TeachersService],
+      providers: [
+        TeachersService,
+        {
+          provide: ValidateFieldsService,
+          useValue: {
+            validateCpf: jest.fn(),
+            validateEmail: jest.fn(),
+            isActive: jest.fn(),
+          },
+        },
+        {
+          provide: getModelToken(Teachers.name),
+          useValue: mockTeacherModel,
+        },
+      ],
     }).compile();
 
     service = module.get<TeachersService>(TeachersService);
+    validateFieldsService = module.get<ValidateFieldsService>(
+      ValidateFieldsService,
+    );
+    model = module.get<Model<TeacherDocument>>(getModelToken(Teachers.name));
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should create a teacher succesfully', async () => {
+    const newTeacher = {
+      name: 'Test',
+      cpf: '12345678910',
+      email: 'test@gmail.com',
+      hourPrice: 5,
+      description: 'Unit tests with jest',
+      modalities: [
+        new Types.ObjectId('64f1b2a3c4d5e6f7890abc12'),
+        new Types.ObjectId('64f1b2a3c4d5e6f7890abc34'),
+      ],
+      image: Buffer.from('new-fake-image'),
+    } as TeacherDocument;
+
+    const teacher = {
+      _id: new Types.ObjectId('64f1b2a3c4d5e6f7890abc15'),
+      name: 'Test',
+      cpf: '12345678910',
+      email: 'test@gmail.com',
+      hourPrice: 5,
+      description: 'Unit tests with jest',
+      modalities: [
+        {
+          name: 'Judô',
+          description: 'Modalidade Judô',
+        },
+        {
+          name: 'Jiu-Jitsu',
+          description: 'Modalidade Jiu-Jitsu',
+        },
+      ],
+      image: Buffer.from('new-fake-image'),
+    };
+
+    validateFieldsService.validateCpf = jest.fn().mockImplementation(() => {});
+    validateFieldsService.validateEmail = jest
+      .fn()
+      .mockImplementation(() => {});
+
+    newTeacher.modalities.forEach(() => {
+      validateFieldsService.isActive = jest.fn().mockImplementation(() => {});
+    });
+
+    mockTeacherModel.create.mockResolvedValue({
+      ...newTeacher,
+      _id: teacher._id,
+    });
+    mockTeacherModel.findById.mockReturnThis();
+    mockTeacherModel.exec.mockResolvedValue(teacher);
+
+    const result = await service.createTeacher(newTeacher);
+
+    expect(result).toEqual(teacher);
+    expect(validateFieldsService.validateCpf).toHaveBeenCalledWith(
+      'Teachers',
+      newTeacher.cpf,
+    );
+    expect(validateFieldsService.validateEmail).toHaveBeenCalledWith(
+      'Teachers',
+      newTeacher.email,
+    );
+    newTeacher.modalities.forEach((modalityId) => {
+      expect(validateFieldsService.isActive).toHaveBeenCalledWith(
+        'Modalities',
+        modalityId,
+      );
+    });
+    expect(validateFieldsService.isActive).toHaveBeenCalledTimes(
+      newTeacher.modalities.length,
+    );
+    expect(model.create).toHaveBeenCalledWith(newTeacher);
+    expect(model.findById).toHaveBeenCalledWith(teacher._id);
   });
 });

--- a/src/modules/teachers/teachers.service.spec.ts
+++ b/src/modules/teachers/teachers.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TeachersService } from './teachers.service';
+
+describe('TeachersService', () => {
+  let service: TeachersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TeachersService],
+    }).compile();
+
+    service = module.get<TeachersService>(TeachersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -14,11 +14,22 @@ export class TeachersService {
     private readonly validateFieldsService: ValidateFieldsService,
   ) {}
 
-  public async createTeacher(newTeacher: TeacherDocument) {
+  public async createTeacher(
+    newTeacher: TeacherDocument,
+  ): Promise<TeacherDocument> {
     await this.validateFieldsService.validateCpf('Teachers', newTeacher.cpf);
     await this.validateFieldsService.validateEmail(
       'Teachers',
       newTeacher.email,
     );
+
+    const modalitiesPromise = newTeacher.modalities.map(async (modalityId) => {
+      await this.validateFieldsService.isActive('Modalities', modalityId);
+    });
+    await Promise.all(modalitiesPromise);
+
+    const teacher = await this.teachersModel.create(newTeacher);
+
+    return await this.teachersModel.findById(teacher._id).exec();
   }
 }

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -5,6 +5,7 @@ import { Model } from 'mongoose';
 import { Teachers } from './schemas/teachers.schema';
 
 import { ModalitiesService } from '@ds-modules/modalities/modalities.service';
+import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
 
 @Injectable()
 export class TeachersService {
@@ -12,4 +13,6 @@ export class TeachersService {
     @InjectModel(Teachers.name) private teachersModel: Model<Teachers>,
     private readonly modalitiesService: ModalitiesService,
   ) {}
+
+  public async createTeacher(newTeacher: TeacherDocument) {}
 }

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import { Teachers } from './schemas/teachers.schema';
+
+import { ModalitiesService } from '@ds-modules/modalities/modalities.service';
+
+@Injectable()
+export class TeachersService {
+  constructor(
+    @InjectModel(Teachers.name) private teachersModel: Model<Teachers>,
+    private readonly modalitiesService: ModalitiesService,
+  ) {}
+}

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -4,15 +4,21 @@ import { Model } from 'mongoose';
 
 import { Teachers } from './schemas/teachers.schema';
 
-import { ModalitiesService } from '@ds-modules/modalities/modalities.service';
 import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
+import { ValidateFieldsService } from '@ds-services/validate-fields/validate-fields.service';
 
 @Injectable()
 export class TeachersService {
   constructor(
     @InjectModel(Teachers.name) private teachersModel: Model<Teachers>,
-    private readonly modalitiesService: ModalitiesService,
+    private readonly validateFieldsService: ValidateFieldsService,
   ) {}
 
-  public async createTeacher(newTeacher: TeacherDocument) {}
+  public async createTeacher(newTeacher: TeacherDocument) {
+    await this.validateFieldsService.validateCpf('Teachers', newTeacher.cpf);
+    await this.validateFieldsService.validateEmail(
+      'Teachers',
+      newTeacher.email,
+    );
+  }
 }


### PR DESCRIPTION
## O que foi feito
Funcionaliade do cadastro. Para isso foi desenvolvido:
- Endpoint `POST - api/v1/teachers`
- Para o endpoint é esperado um body do tipo `multipart/form-data`, com os seguinte dados:
     - `name`: text
     - `cpf`: text
     - `email`: text
     - `hourPrice`: text
     - `description`: text
     - `modalities[]`: text
     - `image`: file
- Service `ValidadeFields` para validar campos de email, cpf e status
- Pre-query no schema de `teachers` para realizar `populate` do campo `modalities` em consultas com `find`
- Limite de 5 requisições por minuto para este endpoint
- Documentação completa da rota no Swagger
- Testes unitários para casos de sucesso e falha

#### [Ticket Trello - Cadastrar novo professor](https://trello.com/c/IGxMmkuP/44-cadastrar-novo-professor)