### PR TITLE
Feat/find teacher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.7",
+        "date-fns": "^4.1.0",
         "mongoose": "^8.17.0",
         "multer": "^2.0.2",
         "passport-jwt": "^4.0.1",
@@ -5389,6 +5390,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",
+    "date-fns": "^4.1.0",
     "mongoose": "^8.17.0",
     "multer": "^2.0.2",
     "passport-jwt": "^4.0.1",

--- a/src/common/types/teacher-report.type.ts
+++ b/src/common/types/teacher-report.type.ts
@@ -1,0 +1,11 @@
+import { TeacherDocument } from './documents/teacher-document.type';
+
+export type TeacherReport = {
+  teacher: TeacherDocument;
+  report: {
+    workload: number | string;
+    salarie: number;
+    month: number;
+    year: number;
+  };
+};

--- a/src/common/types/teacher-report.type.ts
+++ b/src/common/types/teacher-report.type.ts
@@ -3,8 +3,8 @@ import { TeacherDocument } from './documents/teacher-document.type';
 export type TeacherReport = {
   teacher: TeacherDocument;
   report: {
-    workload: number | string;
-    salarie: number;
+    workload: string;
+    salarie: string;
     month: number;
     year: number;
   };

--- a/src/modules/classes/classes.module.ts
+++ b/src/modules/classes/classes.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { ClassesSchema } from './schemas/classes.schema';
@@ -18,13 +18,14 @@ import { PlansModule } from '@ds-modules/plans/plans.module';
       { name: 'Classes', schema: ClassesSchema },
       { name: 'ClassesHistory', schema: ClassesHistorySchema },
     ]),
+    forwardRef(() => TeachersModule),
     ServicesModule,
     ModalitiesModule,
-    TeachersModule,
     PlansModule,
     PipesModule,
   ],
   controllers: [ClassesController],
   providers: [ClassesService],
+  exports: [ClassesService],
 })
 export class ClassesModule {}

--- a/src/modules/classes/classes.service.spec.ts
+++ b/src/modules/classes/classes.service.spec.ts
@@ -150,7 +150,7 @@ describe('ClassesService', () => {
       },
     });
     expect(modalitiesService.findById).toHaveBeenCalledWith(newClass.modality);
-    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher);
+    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher, []);
     expect(classesModel.create).toHaveBeenCalledWith(newClass);
   });
 
@@ -194,7 +194,7 @@ describe('ClassesService', () => {
       ),
     );
     expect(modalitiesService.findById).toHaveBeenCalledWith(newClass.modality);
-    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher);
+    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher, []);
     expect(classesModel.create).toHaveBeenCalledTimes(0);
   });
 
@@ -238,7 +238,7 @@ describe('ClassesService', () => {
       ),
     );
     expect(modalitiesService.findById).toHaveBeenCalledWith(newClass.modality);
-    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher);
+    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher, []);
     expect(classesModel.create).toHaveBeenCalledTimes(0);
   });
 
@@ -282,7 +282,7 @@ describe('ClassesService', () => {
       ),
     );
     expect(modalitiesService.findById).toHaveBeenCalledWith(newClass.modality);
-    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher);
+    expect(teachersService.findById).toHaveBeenCalledWith(newClass.teacher, []);
     expect(classesModel.create).toHaveBeenCalledTimes(0);
   });
 

--- a/src/modules/classes/classes.service.spec.ts
+++ b/src/modules/classes/classes.service.spec.ts
@@ -80,7 +80,7 @@ describe('ClassesService', () => {
     expect(service).toBeDefined();
   });
 
-  it('shoud create a class sucessfully', async () => {
+  it('shoud create a class successfully', async () => {
     const newClass = {
       modality: new Types.ObjectId('60c72b2f9b1d8c001c8e4e1a'),
       teacher: new Types.ObjectId('60c72b2f9b1d8c001c8e4e2b'),

--- a/src/modules/classes/classes.service.ts
+++ b/src/modules/classes/classes.service.ts
@@ -1,5 +1,7 @@
 import {
   BadRequestException,
+  forwardRef,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -22,6 +24,8 @@ export class ClassesService {
     @InjectModel(ClassesHistory.name)
     private classesHistoryModel: Model<ClassesHistory>,
     private readonly modalitiesService: ModalitiesService,
+
+    @Inject(forwardRef(() => TeachersService))
     private readonly teachersService: TeachersService,
   ) {}
 
@@ -167,5 +171,15 @@ export class ClassesService {
     }
 
     return classObj;
+  }
+
+  public async findByTeacher(
+    id: Types.ObjectId,
+  ): Promise<Pick<ClassDocument, 'hour' | 'weekDays'>[]> {
+    const classes = await this.classesModel
+      .find({ teacher: id, status: true }, { hour: 1, weekDays: 1 })
+      .exec();
+
+    return classes;
   }
 }

--- a/src/modules/classes/classes.service.ts
+++ b/src/modules/classes/classes.service.ts
@@ -32,7 +32,7 @@ export class ClassesService {
   public async createClass(newClass: ClassDocument): Promise<ClassDocument> {
     const [modality, teacher] = await Promise.all([
       this.modalitiesService.findById(newClass.modality),
-      this.teachersService.findById(newClass.teacher),
+      this.teachersService.findById(newClass.teacher, []),
     ]);
 
     if (!modality.status) {

--- a/src/modules/modalities/modalities.service.spec.ts
+++ b/src/modules/modalities/modalities.service.spec.ts
@@ -167,7 +167,7 @@ describe('ModalitiesService', () => {
     expect(mockModalitiesModel.limit).toHaveBeenCalledWith(queryParams.limit);
   });
 
-  it('should update a modality sucessfully', async () => {
+  it('should update a modality successfully', async () => {
     const modality: Partial<ModalitiesDocument> = {
       _id: '60c72b2f9b1d8c001c8e4e1a',
       name: 'Old Name Test',

--- a/src/modules/plans/plans.controller.spec.ts
+++ b/src/modules/plans/plans.controller.spec.ts
@@ -38,7 +38,7 @@ describe('PlansController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should create a plan sucessfully', async () => {
+  it('should create a plan successfully', async () => {
     const dto: PlanDto = {
       period: Period.MONTHLY,
       periodQuantity: 3,

--- a/src/modules/plans/plans.service.spec.ts
+++ b/src/modules/plans/plans.service.spec.ts
@@ -61,7 +61,7 @@ describe('PlansService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should create a plan sucessfully', async () => {
+  it('should create a plan successfully', async () => {
     const dto: PlanDto = {
       period: Period.MONTHLY,
       periodQuantity: 3,
@@ -126,7 +126,7 @@ describe('PlansService', () => {
     expect(model.findById).toHaveBeenCalledTimes(0);
   });
 
-  it('should find a plan by id sucessfully', async () => {
+  it('should find a plan by id successfully', async () => {
     const id = '60c72b2f9b1d8c001c8e4e1a';
     const plan = {
       _id: id,

--- a/src/modules/teachers/dtos/date.dto.ts
+++ b/src/modules/teachers/dtos/date.dto.ts
@@ -1,7 +1,11 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsNumber, IsOptional, Max, Min } from 'class-validator';
 
 export class DateDto {
+  @ApiPropertyOptional({
+    description: 'Número do mês para carga de trabalho e salário mensal',
+  })
   @IsOptional()
   @Transform(({ value }) => parseInt(value))
   @IsNumber()
@@ -9,6 +13,9 @@ export class DateDto {
   @Max(12)
   month: number;
 
+  @ApiPropertyOptional({
+    description: 'Ano para carga de trabalho e salário mensal',
+  })
   @IsOptional()
   @Transform(({ value }) => parseInt(value))
   @IsNumber()

--- a/src/modules/teachers/dtos/date.dto.ts
+++ b/src/modules/teachers/dtos/date.dto.ts
@@ -1,0 +1,17 @@
+import { Transform } from 'class-transformer';
+import { IsNumber, IsOptional, Max, Min } from 'class-validator';
+
+export class DateDto {
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(1)
+  @Max(12)
+  month: number;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(0)
+  year: number;
+}

--- a/src/modules/teachers/dtos/find-teachers.dto.ts
+++ b/src/modules/teachers/dtos/find-teachers.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsNumber, IsOptional, Min } from 'class-validator';
+import { IsBoolean, IsNumber, IsOptional, Max, Min } from 'class-validator';
 
 export class FindTeachersDto {
   @ApiProperty({ description: 'Número de documentos que serão pulados' })
@@ -20,4 +20,23 @@ export class FindTeachersDto {
   @Transform(({ value }) => value === 'true')
   @IsBoolean()
   status: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Número do mês para carga de trabalho e salário mensal',
+  })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(1)
+  @Max(12)
+  month: number;
+
+  @ApiPropertyOptional({
+    description: 'Ano para carga de trabalho e salário mensal',
+  })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(0)
+  year: number;
 }

--- a/src/modules/teachers/dtos/find-teachers.dto.ts
+++ b/src/modules/teachers/dtos/find-teachers.dto.ts
@@ -19,7 +19,7 @@ export class FindTeachersDto {
   @IsOptional()
   @Transform(({ value }) => value === 'true')
   @IsBoolean()
-  status: boolean;
+  status?: boolean;
 
   @ApiPropertyOptional({
     description: 'Número do mês para carga de trabalho e salário mensal',
@@ -29,7 +29,7 @@ export class FindTeachersDto {
   @IsNumber()
   @Min(1)
   @Max(12)
-  month: number;
+  month?: number;
 
   @ApiPropertyOptional({
     description: 'Ano para carga de trabalho e salário mensal',
@@ -38,5 +38,5 @@ export class FindTeachersDto {
   @Transform(({ value }) => parseInt(value))
   @IsNumber()
   @Min(0)
-  year: number;
+  year?: number;
 }

--- a/src/modules/teachers/dtos/find-teachers.dto.ts
+++ b/src/modules/teachers/dtos/find-teachers.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsNumber, IsOptional, Min } from 'class-validator';
+
+export class FindTeachersDto {
+  @ApiProperty({ description: 'Número de documentos que serão pulados' })
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(0)
+  skip: number;
+
+  @ApiProperty({ description: 'Número de documentos que serão retornados' })
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(1)
+  limit: number;
+
+  @ApiPropertyOptional({ description: 'Status do professor' })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  status: boolean;
+}

--- a/src/modules/teachers/teachers.controller.spec.ts
+++ b/src/modules/teachers/teachers.controller.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Types } from 'mongoose';
+import { Request } from 'express';
 
 import { TeachersController } from './teachers.controller';
 import { TeachersService } from './teachers.service';
 import { TeacherDto } from './dtos/teacher.dto';
+import { DateDto } from './dtos/date.dto';
+import { FindTeachersDto } from './dtos/find-teachers.dto';
 
 import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
 
@@ -20,6 +23,8 @@ describe('TeachersController', () => {
           provide: TeachersService,
           useValue: {
             createTeacher: jest.fn(),
+            findByIdWithRole: jest.fn(),
+            findAllWithRole: jest.fn(),
           },
         },
         {
@@ -86,5 +91,207 @@ describe('TeachersController', () => {
       ...dto,
       image: reducedImage,
     });
+  });
+
+  it('should find teacher by id with admin role', async () => {
+    const id = '60c72b2f9b1d8c001c8e4e1a';
+    const mockReq: Partial<Request> & { user?: { role?: string } } = {
+      user: { role: 'admin' },
+    };
+    const queryParams: DateDto = {
+      month: 9,
+      year: 2025,
+    };
+    const teacherReport = {
+      teacher: {
+        _id: new Types.ObjectId(id),
+        name: 'Test',
+        cpf: '12345678910',
+        email: 'test@gmail.com',
+        hourPrice: 5,
+        description: 'Unit tests with jest',
+        modalities: [
+          {
+            name: 'Judô',
+            description: 'Modalidade Judô',
+          },
+          {
+            name: 'Jiu-Jitsu',
+            description: 'Modalidade Jiu-Jitsu',
+          },
+        ],
+        image: Buffer.from('new-fake-image'),
+      },
+      report: {
+        workload: '30:00',
+        salarie: 150,
+        month: queryParams.month,
+        year: queryParams.year,
+      },
+    };
+
+    teachersService.findByIdWithRole = jest
+      .fn()
+      .mockResolvedValue(teacherReport);
+
+    const result = await controller.findById(
+      id,
+      queryParams,
+      mockReq as Request,
+    );
+
+    expect(result).toEqual({ data: teacherReport });
+    expect(teachersService.findByIdWithRole).toHaveBeenCalledWith(
+      id,
+      mockReq.user.role,
+      queryParams,
+    );
+  });
+
+  it('should find teacher by id without admin role', async () => {
+    const id = '60c72b2f9b1d8c001c8e4e1a';
+    const mockReq: Partial<Request> & { user?: { role?: string } } = {
+      user: { role: undefined },
+    };
+    const queryParams: DateDto = {
+      month: 9,
+      year: 2025,
+    };
+    const teacher = {
+      teacher: {
+        _id: new Types.ObjectId(id),
+        name: 'Test',
+        description: 'Unit tests with jest',
+        modalities: [
+          {
+            name: 'Judô',
+            description: 'Modalidade Judô',
+          },
+          {
+            name: 'Jiu-Jitsu',
+            description: 'Modalidade Jiu-Jitsu',
+          },
+        ],
+        image: Buffer.from('new-fake-image'),
+      },
+    };
+
+    teachersService.findByIdWithRole = jest.fn().mockResolvedValue(teacher);
+
+    const result = await controller.findById(
+      id,
+      queryParams,
+      mockReq as Request,
+    );
+
+    expect(result).toEqual({ data: teacher });
+    expect(teachersService.findByIdWithRole).toHaveBeenCalledWith(
+      id,
+      mockReq.user.role,
+      queryParams,
+    );
+  });
+
+  it('should find all teachers with admin role', async () => {
+    const mockReq: Partial<Request> & { user?: { role?: string } } = {
+      user: { role: 'admin' },
+    };
+    const queryParams: FindTeachersDto = {
+      skip: 0,
+      limit: 5,
+      status: true,
+      month: 9,
+      year: 2025,
+    };
+    const teachers = [
+      {
+        teacher: {
+          _id: new Types.ObjectId('60c72b2f9b1d8c001c8e4e1a'),
+          name: 'Test',
+          cpf: '12345678910',
+          email: 'test@gmail.com',
+          hourPrice: 5,
+          description: 'Unit tests with jest',
+          modalities: [
+            {
+              name: 'Judô',
+              description: 'Modalidade Judô',
+            },
+            {
+              name: 'Jiu-Jitsu',
+              description: 'Modalidade Jiu-Jitsu',
+            },
+          ],
+          image: Buffer.from('new-fake-image'),
+        },
+        report: {
+          workload: '30:00',
+          salarie: 150,
+          month: queryParams.month,
+          year: queryParams.year,
+        },
+      },
+    ];
+
+    teachersService.findAllWithRole = jest.fn().mockResolvedValue(teachers);
+
+    const result = await controller.findAll(queryParams, mockReq as Request);
+
+    expect(result).toEqual({
+      data: teachers,
+      pagination: { skip: queryParams.skip, limit: queryParams.limit },
+      total: teachers.length,
+    });
+    expect(teachersService.findAllWithRole).toHaveBeenCalledWith(
+      mockReq.user.role,
+      queryParams,
+    );
+  });
+
+  it('should find all teachers without admin role', async () => {
+    const mockReq: Partial<Request> & { user?: { role?: string } } = {
+      user: { role: undefined },
+    };
+    const queryParams: FindTeachersDto = {
+      skip: 0,
+      limit: 5,
+      status: true,
+      month: 9,
+      year: 2025,
+    };
+    const teachers = [
+      {
+        teacher: {
+          _id: new Types.ObjectId('60c72b2f9b1d8c001c8e4e1a'),
+          name: 'Test',
+          description: 'Unit tests with jest',
+          modalities: [
+            {
+              name: 'Judô',
+              description: 'Modalidade Judô',
+            },
+            {
+              name: 'Jiu-Jitsu',
+              description: 'Modalidade Jiu-Jitsu',
+            },
+          ],
+          image: Buffer.from('new-fake-image'),
+        },
+      },
+    ];
+
+    teachersService.findAllWithRole = jest.fn().mockResolvedValue(teachers);
+
+    const result = await controller.findAll(queryParams, mockReq as Request);
+
+    expect(result).toEqual({
+      data: teachers,
+      pagination: { skip: queryParams.skip, limit: queryParams.limit },
+      total: teachers.length,
+    });
+    expect(teachersService.findAllWithRole).toHaveBeenCalledWith(
+      mockReq.user.role,
+      queryParams,
+    );
   });
 });

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -1,10 +1,11 @@
 import {
   Body,
   Controller,
+  Get,
+  Param,
   Post,
   UploadedFile,
   UseGuards,
-  UseInterceptors,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { AuthGuard } from '@nestjs/passport';
@@ -14,6 +15,7 @@ import {
   ApiCookieAuth,
   ApiOperation,
 } from '@nestjs/swagger';
+import { Types } from 'mongoose';
 
 import { TeachersService } from './teachers.service';
 import { TeacherDto } from './dtos/teacher.dto';
@@ -21,12 +23,11 @@ import { TeacherDto } from './dtos/teacher.dto';
 import { UploadImage } from '@ds-common/decorators/upload-image.decorator';
 import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
 import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
-import { ImageBase64Interceptor } from '@ds-common/interceptors/image-base64/image-base64.interceptor';
 import { ApiResponse } from '@ds-types/api-response.type';
 import { Roles } from '@ds-common/decorators/roles.decorator';
 import { RoleGuard } from '@ds-common/guards/role/role.guard';
 
-@UseInterceptors(ImageBase64Interceptor)
+// @UseInterceptors(ImageBase64Interceptor)
 @Controller('teachers')
 export class TeachersController {
   constructor(
@@ -121,5 +122,17 @@ export class TeachersController {
     return {
       data: teacher,
     };
+  }
+
+  @Get(':id')
+  public async findById(@Param('id') id: string) {
+    const teacher = await this.teachersService.findById(new Types.ObjectId(id));
+    const workload = await this.teachersService.monthlyWorkload(
+      teacher,
+      9,
+      2025,
+    );
+
+    return this.teachersService.calculateSalarie(teacher.hourPrice, workload);
   }
 }

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -20,10 +20,12 @@ import {
   ApiOperation,
 } from '@nestjs/swagger';
 import { Types } from 'mongoose';
+import { Request } from 'express';
 
 import { TeachersService } from './teachers.service';
 import { TeacherDto } from './dtos/teacher.dto';
 import { DateDto } from './dtos/date.dto';
+import { FindTeachersDto } from './dtos/find-teachers.dto';
 
 import { UploadImage } from '@ds-common/decorators/upload-image.decorator';
 import { ReduceImagePipe } from '@ds-common/pipes/reduce-image/reduce-image.pipe';
@@ -145,7 +147,7 @@ export class TeachersController {
 
     const role = req['user']?.role;
 
-    const teacherData = await this.teachersService.findWithRole(
+    const teacherData = await this.teachersService.findByIdWithRole(
       id,
       role,
       queryParams,
@@ -153,6 +155,29 @@ export class TeachersController {
 
     return {
       data: teacherData,
+    };
+  }
+
+  @UseGuards(OptionalJwtGuard)
+  @Get()
+  public async findAll(
+    @Query() queryParams: FindTeachersDto & DateDto,
+    @Req() req: Request,
+  ): Promise<ApiResponse<TeacherReport[] | TeacherDocument[]>> {
+    const role = req['user']?.role;
+
+    const teachersData = await this.teachersService.findAllWithRole(
+      role,
+      queryParams,
+    );
+
+    return {
+      data: teachersData,
+      pagination: {
+        skip: queryParams.skip,
+        limit: queryParams.limit,
+      },
+      total: teachersData.length,
     };
   }
 }

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -134,6 +134,13 @@ export class TeachersController {
     };
   }
 
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: 'Buscar um professor por ID',
+    description: `Qualquer usuário pode realizar está ação. No entanto, 
+      apenas usuários com token jwt e cargos "admin" recebem
+      informações pessoais sobre o professor`,
+  })
   @UseGuards(OptionalJwtGuard)
   @Get(':id')
   public async findById(
@@ -158,10 +165,17 @@ export class TeachersController {
     };
   }
 
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: 'Buscar todos os professores com paginção e filtro por status',
+    description: `Qualquer usuário pode realizar está ação. No entanto, 
+      apenas usuários com token jwt e cargos "admin" recebem
+      informações pessoais sobre o professor`,
+  })
   @UseGuards(OptionalJwtGuard)
   @Get()
   public async findAll(
-    @Query() queryParams: FindTeachersDto & DateDto,
+    @Query() queryParams: FindTeachersDto,
     @Req() req: Request,
   ): Promise<ApiResponse<TeacherReport[] | TeacherDocument[]>> {
     const role = req['user']?.role;

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -142,6 +142,12 @@ export class TeachersController {
       informações pessoais sobre o professor`,
   })
   @UseGuards(OptionalJwtGuard)
+  @Throttle({
+    default: {
+      limit: 20,
+      ttl: 60000,
+    },
+  })
   @Get(':id')
   public async findById(
     @Param('id') id: string,
@@ -173,6 +179,12 @@ export class TeachersController {
       informações pessoais sobre o professor`,
   })
   @UseGuards(OptionalJwtGuard)
+  @Throttle({
+    default: {
+      limit: 20,
+      ttl: 60000,
+    },
+  })
   @Get()
   public async findAll(
     @Query() queryParams: FindTeachersDto,

--- a/src/modules/teachers/teachers.module.ts
+++ b/src/modules/teachers/teachers.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { TeachersSchema } from './schemas/teachers.schema';
@@ -8,10 +8,12 @@ import { TeachersService } from './teachers.service';
 import { ModalitiesModule } from '@ds-modules/modalities/modalities.module';
 import { ServicesModule } from '@ds-services/services.module';
 import { PipesModule } from '@ds-common/pipes/pipes.module';
+import { ClassesModule } from '@ds-modules/classes/classes.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: 'Teachers', schema: TeachersSchema }]),
+    forwardRef(() => ClassesModule),
     ModalitiesModule,
     ServicesModule,
     PipesModule,

--- a/src/modules/teachers/teachers.service.spec.ts
+++ b/src/modules/teachers/teachers.service.spec.ts
@@ -1,16 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Model, Types } from 'mongoose';
 import { getModelToken } from '@nestjs/mongoose';
+import { NotFoundException } from '@nestjs/common';
 
 import { TeachersService } from './teachers.service';
 import { Teachers } from './schemas/teachers.schema';
+import { FindTeachersDto } from './dtos/find-teachers.dto';
+import { DateDto } from './dtos/date.dto';
 
 import { ValidateFieldsService } from '@ds-services/validate-fields/validate-fields.service';
 import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
+import { ClassesService } from '@ds-modules/classes/classes.service';
+import { WeekDays } from '@ds-enums/week-days.enum';
 
 describe('TeachersService', () => {
   let service: TeachersService;
   let validateFieldsService: ValidateFieldsService;
+  let classesService: ClassesService;
 
   let model: Model<TeacherDocument>;
 
@@ -41,6 +47,12 @@ describe('TeachersService', () => {
           },
         },
         {
+          provide: ClassesService,
+          useValue: {
+            findByTeacher: jest.fn(),
+          },
+        },
+        {
           provide: getModelToken(Teachers.name),
           useValue: mockTeacherModel,
         },
@@ -51,7 +63,10 @@ describe('TeachersService', () => {
     validateFieldsService = module.get<ValidateFieldsService>(
       ValidateFieldsService,
     );
+    classesService = module.get<ClassesService>(ClassesService);
     model = module.get<Model<TeacherDocument>>(getModelToken(Teachers.name));
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -130,5 +145,328 @@ describe('TeachersService', () => {
     );
     expect(model.create).toHaveBeenCalledWith(newTeacher);
     expect(model.findById).toHaveBeenCalledWith(teacher._id);
+  });
+
+  it('should calculate salarie successfully', () => {
+    const workload = 30;
+    const hourPrice = 5;
+
+    const result = service.calculateSalarie(hourPrice, workload);
+
+    expect(result).toEqual((hourPrice * workload).toFixed(2));
+  });
+
+  it("should calculate the teacher's monthly workload successfully", async () => {
+    const teacherId = new Types.ObjectId();
+    const month = 9;
+    const year = 2025;
+    const classes = [
+      {
+        hour: {
+          start: '17:00',
+          end: '18:00',
+        },
+        weekDays: [WeekDays.MONDAY, WeekDays.WEDNESDAY],
+      },
+      {
+        hour: {
+          start: '18:00',
+          end: '19:00',
+        },
+        weekDays: [WeekDays.MONDAY, WeekDays.WEDNESDAY],
+      },
+    ];
+
+    classesService.findByTeacher = jest.fn().mockResolvedValue(classes);
+
+    const result = await service.monthlyWorkload(teacherId, month, year);
+
+    expect(result).toEqual(18);
+  });
+
+  it('should return 0 if the teacher has no classes', async () => {
+    const teacherId = new Types.ObjectId();
+    const month = 9;
+    const year = 2025;
+
+    classesService.findByTeacher = jest.fn().mockResolvedValue([]);
+
+    const result = await service.monthlyWorkload(teacherId, month, year);
+
+    expect(result).toEqual(0);
+  });
+
+  it('should find all teachers', async () => {
+    const queryParams: FindTeachersDto = {
+      skip: 0,
+      limit: 0,
+      status: true,
+    };
+    const teachers = [
+      {
+        _id: new Types.ObjectId('64f1b2a3c4d5e6f7890abc15'),
+        name: 'Test',
+        cpf: '12345678910',
+        email: 'test@gmail.com',
+        hourPrice: 5,
+        description: 'Unit tests with jest',
+        modalities: [
+          {
+            name: 'Judô',
+            description: 'Modalidade Judô',
+          },
+          {
+            name: 'Jiu-Jitsu',
+            description: 'Modalidade Jiu-Jitsu',
+          },
+        ],
+        image: Buffer.from('new-fake-image'),
+      },
+    ];
+
+    mockTeacherModel.find.mockReturnThis();
+    mockTeacherModel.skip.mockReturnThis();
+    mockTeacherModel.limit.mockReturnThis();
+    mockTeacherModel.where.mockReturnThis();
+    mockTeacherModel.equals.mockReturnThis();
+    mockTeacherModel.exec.mockResolvedValue(teachers);
+
+    const result = await service.findAll(queryParams, []);
+
+    expect(result).toEqual(teachers);
+    expect(model.find).toHaveBeenCalledWith({}, {});
+    expect(result.length).toBe(teachers.length);
+    expect(mockTeacherModel.skip).toHaveBeenCalledWith(queryParams.skip);
+    expect(mockTeacherModel.limit).toHaveBeenCalledWith(queryParams.limit);
+    expect(mockTeacherModel.where).toHaveBeenCalledWith('status');
+    expect(mockTeacherModel.equals).toHaveBeenCalledWith(queryParams.status);
+  });
+
+  it('should find by id successfully', async () => {
+    const id = new Types.ObjectId();
+    const teacher = {
+      _id: id,
+      name: 'Test',
+      cpf: '12345678910',
+      email: 'test@gmail.com',
+      hourPrice: 5,
+      description: 'Unit tests with jest',
+      modalities: [
+        {
+          name: 'Judô',
+          description: 'Modalidade Judô',
+        },
+        {
+          name: 'Jiu-Jitsu',
+          description: 'Modalidade Jiu-Jitsu',
+        },
+      ],
+      image: Buffer.from('new-fake-image'),
+    };
+
+    mockTeacherModel.findById.mockReturnThis();
+    mockTeacherModel.exec.mockReturnValue(teacher);
+
+    const result = await service.findById(id, []);
+
+    expect(result).toEqual(teacher);
+    expect(model.findById).toHaveBeenCalledWith(id, {});
+  });
+
+  it("should throw NotFoundException if teacher doesn't exist", async () => {
+    const id = new Types.ObjectId();
+
+    mockTeacherModel.findById.mockReturnThis();
+    mockTeacherModel.exec.mockReturnValue(null);
+
+    await expect(service.findById(id, [])).rejects.toThrow(
+      new NotFoundException(`Teacher with id ${id} not found`),
+    );
+    expect(model.findById).toHaveBeenCalledWith(id, {});
+  });
+
+  it('should find all teachers with admin role', async () => {
+    const role = 'admin';
+    const queryParams: FindTeachersDto = {
+      skip: 0,
+      limit: 0,
+      status: true,
+      month: 9,
+      year: 2025,
+    };
+    const teachers = [
+      {
+        _id: new Types.ObjectId('64f1b2a3c4d5e6f7890abc15'),
+        name: 'Test',
+        cpf: '12345678910',
+        email: 'test@gmail.com',
+        hourPrice: 5,
+        description: 'Unit tests with jest',
+        modalities: [
+          {
+            name: 'Judô',
+            description: 'Modalidade Judô',
+          },
+          {
+            name: 'Jiu-Jitsu',
+            description: 'Modalidade Jiu-Jitsu',
+          },
+        ],
+        image: Buffer.from('new-fake-image'),
+      },
+    ];
+    const workload = 30;
+    const salarie = '150';
+    const teachersReport = teachers.map((teacher) => {
+      return {
+        teacher,
+        report: {
+          workload: '30:00',
+          salarie,
+          month: queryParams.month,
+          year: queryParams.year,
+        },
+      };
+    });
+
+    service.findAll = jest.fn().mockResolvedValue(teachers);
+    service.monthlyWorkload = jest.fn().mockResolvedValue(workload);
+    service.calculateSalarie = jest.fn().mockReturnValue(salarie);
+
+    const result = await service.findAllWithRole(role, queryParams);
+
+    expect(result).toEqual(teachersReport);
+    expect(service.findAll).toHaveBeenCalledWith(queryParams, []);
+    expect(service.monthlyWorkload).toHaveBeenCalledTimes(teachers.length);
+    expect(service.calculateSalarie).toHaveBeenCalledTimes(teachers.length);
+  });
+
+  it('should find all teachers without admin role', async () => {
+    const role = undefined;
+    const queryParams: FindTeachersDto = {
+      skip: 0,
+      limit: 0,
+      status: true,
+    };
+    const teachers = [
+      {
+        _id: new Types.ObjectId('64f1b2a3c4d5e6f7890abc15'),
+        name: 'Test',
+        description: 'Unit tests with jest',
+        modalities: [
+          {
+            name: 'Judô',
+            description: 'Modalidade Judô',
+          },
+          {
+            name: 'Jiu-Jitsu',
+            description: 'Modalidade Jiu-Jitsu',
+          },
+        ],
+        image: Buffer.from('new-fake-image'),
+      },
+    ];
+
+    service.findAll = jest.fn().mockResolvedValue(teachers);
+    service.monthlyWorkload = jest.fn();
+    service.calculateSalarie = jest.fn();
+
+    const result = await service.findAllWithRole(role, queryParams);
+
+    expect(result).toEqual(teachers);
+    expect(service.findAll).toHaveBeenCalledWith(queryParams, [
+      'name',
+      'description',
+      'image',
+    ]);
+    expect(service.monthlyWorkload).toHaveBeenCalledTimes(0);
+    expect(service.calculateSalarie).toHaveBeenCalledTimes(0);
+  });
+
+  it('should find teacher by id with admin role', async () => {
+    const id = '64f1b2a3c4d5e6f7890abc15';
+    const role = 'admin';
+    const queryParams: DateDto = {
+      month: 9,
+      year: 2025,
+    };
+    const teacher = {
+      _id: new Types.ObjectId(id),
+      name: 'Test',
+      cpf: '12345678910',
+      email: 'test@gmail.com',
+      hourPrice: 5,
+      description: 'Unit tests with jest',
+      modalities: [
+        {
+          name: 'Judô',
+          description: 'Modalidade Judô',
+        },
+        {
+          name: 'Jiu-Jitsu',
+          description: 'Modalidade Jiu-Jitsu',
+        },
+      ],
+      image: Buffer.from('new-fake-image'),
+    };
+    const workload = 30;
+    const salarie = '150';
+    const teachersReport = {
+      teacher,
+      report: {
+        workload: '30:00',
+        salarie,
+        month: queryParams.month,
+        year: queryParams.year,
+      },
+    };
+
+    service.findById = jest.fn().mockResolvedValue(teacher);
+    service.monthlyWorkload = jest.fn().mockResolvedValue(workload);
+    service.calculateSalarie = jest.fn().mockReturnValue(salarie);
+
+    const result = await service.findByIdWithRole(id, role, queryParams);
+
+    expect(result).toEqual(teachersReport);
+    expect(service.findById).toHaveBeenCalledWith(teacher._id, []);
+  });
+
+  it('should find teacher by id without admin role', async () => {
+    const id = '64f1b2a3c4d5e6f7890abc15';
+    const role = undefined;
+    const queryParams: DateDto = {
+      month: 9,
+      year: 2025,
+    };
+    const teacher = {
+      _id: new Types.ObjectId(id),
+      name: 'Test',
+      description: 'Unit tests with jest',
+      modalities: [
+        {
+          name: 'Judô',
+          description: 'Modalidade Judô',
+        },
+        {
+          name: 'Jiu-Jitsu',
+          description: 'Modalidade Jiu-Jitsu',
+        },
+      ],
+      image: Buffer.from('new-fake-image'),
+    };
+    service.findById = jest.fn().mockResolvedValue(teacher);
+    service.monthlyWorkload = jest.fn();
+    service.calculateSalarie = jest.fn();
+
+    const result = await service.findByIdWithRole(id, role, queryParams);
+
+    expect(result).toEqual(teacher);
+    expect(service.findById).toHaveBeenCalledWith(teacher._id, [
+      'name',
+      'description',
+      'image',
+    ]);
+    expect(service.monthlyWorkload).toHaveBeenCalledTimes(0);
+    expect(service.calculateSalarie).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -55,11 +55,10 @@ export class TeachersService {
   }
 
   public async monthlyWorkload(
-    id: Types.ObjectId,
+    teacher: TeacherDocument,
     month: number,
     year: number,
   ): Promise<number> {
-    const teacher = await this.findById(id);
     const classes = await this.classesService.findByTeacher(teacher.id);
 
     let totalMinutes = 0;
@@ -78,14 +77,22 @@ export class TeachersService {
         endHour * 60 + endMinute - (startHour * 60 + startMinute);
 
       const classDays = days.filter((day) =>
-        classDoc.weekDays.includes(
-          day.toLocaleDateString('pt-BR', { weekday: 'long' }) as WeekDays,
+        classDoc.weekDays.some(
+          (weekDay) =>
+            weekDay.toLocaleLowerCase() ===
+            (
+              day.toLocaleDateString('pt-BR', { weekday: 'long' }) as WeekDays
+            ).toLocaleLowerCase(),
         ),
       );
 
       totalMinutes += classDays.length * durationMinutes;
     }
 
-    return totalMinutes;
+    return totalMinutes / 60;
+  }
+
+  public calculateSalarie(hourPrice: number, workload: number): number {
+    return workload * hourPrice;
   }
 }

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -1,17 +1,28 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
+import { startOfMonth, endOfMonth, eachDayOfInterval } from 'date-fns';
 
 import { Teachers } from './schemas/teachers.schema';
 
 import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
 import { ValidateFieldsService } from '@ds-services/validate-fields/validate-fields.service';
+import { ClassesService } from '@ds-modules/classes/classes.service';
+import { WeekDays } from '@ds-enums/week-days.enum';
 
 @Injectable()
 export class TeachersService {
   constructor(
     @InjectModel(Teachers.name) private teachersModel: Model<Teachers>,
     private readonly validateFieldsService: ValidateFieldsService,
+
+    @Inject(forwardRef(() => ClassesService))
+    private readonly classesService: ClassesService,
   ) {}
 
   public async createTeacher(
@@ -41,5 +52,40 @@ export class TeachersService {
     }
 
     return teacher;
+  }
+
+  public async monthlyWorkload(
+    id: Types.ObjectId,
+    month: number,
+    year: number,
+  ): Promise<number> {
+    const teacher = await this.findById(id);
+    const classes = await this.classesService.findByTeacher(teacher.id);
+
+    let totalMinutes = 0;
+
+    const start = startOfMonth(new Date(year, month - 1));
+    const end = endOfMonth(new Date(year, month - 1));
+    const days = eachDayOfInterval({ start, end });
+
+    for (const classDoc of classes) {
+      const [startHour, startMinute] = classDoc.hour.start
+        .split(':')
+        .map(Number);
+      const [endHour, endMinute] = classDoc.hour.end.split(':').map(Number);
+
+      const durationMinutes =
+        endHour * 60 + endMinute - (startHour * 60 + startMinute);
+
+      const classDays = days.filter((day) =>
+        classDoc.weekDays.includes(
+          day.toLocaleDateString('pt-BR', { weekday: 'long' }) as WeekDays,
+        ),
+      );
+
+      totalMinutes += classDays.length * durationMinutes;
+    }
+
+    return totalMinutes;
   }
 }

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -94,12 +94,12 @@ export class TeachersService {
 
     const reportPromises = teachers.map(async (teacher) => {
       const workload = await this.monthlyWorkload(teacher.id, month, year);
-      const salarie = await this.calculateSalarie(teacher.id, workload);
+      const salarie = this.calculateSalarie(teacher.hourPrice, workload);
 
       return {
         teacher,
         report: {
-          workload,
+          workload: this.hoursToHHMM(workload),
           salarie,
           month,
           year,

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -81,7 +81,7 @@ export class TeachersService {
 
   public async findAllWithRole(
     role: Role,
-    queryParams: FindTeachersDto & DateDto,
+    queryParams: FindTeachersDto,
   ): Promise<TeacherReport[] | TeacherDocument[]> {
     if (role !== 'admin') {
       return await this.findAll(queryParams, ['name', 'description', 'image']);

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -9,11 +9,14 @@ import { Model, Types } from 'mongoose';
 import { startOfMonth, endOfMonth, eachDayOfInterval } from 'date-fns';
 
 import { Teachers } from './schemas/teachers.schema';
+import { DateDto } from './dtos/date.dto';
 
 import { TeacherDocument } from '@ds-types/documents/teacher-document.type';
 import { ValidateFieldsService } from '@ds-services/validate-fields/validate-fields.service';
 import { ClassesService } from '@ds-modules/classes/classes.service';
 import { WeekDays } from '@ds-enums/week-days.enum';
+import { Role } from '@ds-types/role.type';
+import { TeacherReport } from '@ds-types/teacher-report.type';
 
 @Injectable()
 export class TeachersService {
@@ -44,8 +47,44 @@ export class TeachersService {
     return await this.teachersModel.findById(teacher._id).exec();
   }
 
-  public async findById(id: Types.ObjectId): Promise<TeacherDocument> {
-    const teacher = await this.teachersModel.findById(id).exec();
+  public async findWithRole(
+    id: string,
+    role: Role,
+    queryParams: DateDto,
+  ): Promise<TeacherReport | TeacherDocument> {
+    if (role !== 'admin') {
+      return await this.findById(new Types.ObjectId(id), [
+        'name',
+        'description',
+        'image',
+      ]);
+    }
+
+    const month = queryParams.month ?? new Date().getMonth() + 1;
+    const year = queryParams.year ?? new Date().getFullYear();
+
+    const teacher = await this.findById(new Types.ObjectId(id), []);
+    const workload = await this.monthlyWorkload(teacher.id, month, year);
+    const salarie = this.calculateSalarie(teacher.hourPrice, workload);
+
+    return {
+      teacher: teacher.toObject(),
+      report: {
+        workload: this.hoursToHHMM(workload),
+        salarie,
+        month,
+        year,
+      },
+    };
+  }
+
+  public async findById(
+    id: Types.ObjectId,
+    fields: (keyof TeacherDocument)[],
+  ): Promise<TeacherDocument> {
+    const projection = Object.fromEntries(fields.map((key) => [key, 1]));
+
+    const teacher = await this.teachersModel.findById(id, projection).exec();
 
     if (!teacher) {
       throw new NotFoundException(`Teacher with id ${id} not found`);
@@ -55,11 +94,11 @@ export class TeachersService {
   }
 
   public async monthlyWorkload(
-    teacher: TeacherDocument,
+    teacherId: Types.ObjectId,
     month: number,
     year: number,
   ): Promise<number> {
-    const classes = await this.classesService.findByTeacher(teacher.id);
+    const classes = await this.classesService.findByTeacher(teacherId);
 
     let totalMinutes = 0;
 
@@ -94,5 +133,14 @@ export class TeachersService {
 
   public calculateSalarie(hourPrice: number, workload: number): number {
     return workload * hourPrice;
+  }
+
+  private hoursToHHMM(hours: number): string {
+    const hour = Math.floor(hours);
+    const minute = Math.round((hours - hour) * 60);
+    const hh = String(hour).padStart(2, '0');
+    const mm = String(minute).padStart(2, '0');
+
+    return `${hh}:${mm}`;
   }
 }

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -69,7 +69,7 @@ export class TeachersService {
     const salarie = this.calculateSalarie(teacher.hourPrice, workload);
 
     return {
-      teacher: teacher.toObject(),
+      teacher: teacher,
       report: {
         workload: this.hoursToHHMM(workload),
         salarie,

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -182,8 +182,10 @@ export class TeachersService {
     return totalMinutes / 60;
   }
 
-  public calculateSalarie(hourPrice: number, workload: number): number {
-    return workload * hourPrice;
+  public calculateSalarie(hourPrice: number, workload: number): string {
+    const salarie = workload * hourPrice;
+
+    return salarie.toFixed(2);
   }
 
   private hoursToHHMM(hours: number): string {


### PR DESCRIPTION
## O que foi feito
Funcionalidade de busca dos professores. Para isso foi desenvolvido dois endpoints:

- `GET api/v1/teachers/{id}`: busca um professor pelo seu id
- `GET api/v1/teachers`: lista todos os professores com suporte a paginaçãoe e filtro por status
- A response varia conforme o `role` do usuário:
     - Sem autenticação jwt ou com `role` diferente de `admin`: retorna apenas os campos `name`, `description`, `image` e `modalities` do professor
     - Com autenticação jwt e `role` `admin`: retorna todas as informações pessoais do professor, sua carga horária mensal e salário
- Limite máximo de 20 requisições por minuto
- Documentação dos endpoints no Swagger
- Testes unitários nos casos de sucesso e falha

[Ticket Trello - Buscar professor](https://trello.com/c/rm1Lug57/45-buscar-professores)