### PR TITLE
Feat/update teacher

### DIFF
--- a/src/modules/classes/classes.service.ts
+++ b/src/modules/classes/classes.service.ts
@@ -173,13 +173,16 @@ export class ClassesService {
     return classObj;
   }
 
-  public async findByTeacher(
+  public async findByTeacher<K extends keyof ClassDocument>(
     id: Types.ObjectId,
-  ): Promise<Pick<ClassDocument, 'hour' | 'weekDays'>[]> {
+    fields: K[],
+  ): Promise<Pick<ClassDocument, K>[]> {
+    const projection = Object.fromEntries(fields.map((key) => [key, 1]));
+
     const classes = await this.classesModel
-      .find({ teacher: id, status: true }, { hour: 1, weekDays: 1 })
+      .find({ teacher: id, status: true }, projection)
       .exec();
 
-    return classes;
+    return classes as Pick<ClassDocument, K>[];
   }
 }

--- a/src/modules/teachers/dtos/update-teacher.dto.ts
+++ b/src/modules/teachers/dtos/update-teacher.dto.ts
@@ -1,0 +1,46 @@
+import { Transform } from 'class-transformer';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsEmail,
+  IsMongoId,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Length,
+  Min,
+} from 'class-validator';
+import { Types } from 'mongoose';
+
+export class UpdateTeacherDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(11, 11)
+  cpf?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  description?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsNumber()
+  @Min(1)
+  hourPrice?: number;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsMongoId({ each: true })
+  modalities?: Types.ObjectId[];
+}

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -209,6 +209,58 @@ export class TeachersController {
     };
   }
 
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: 'Atualizar professor',
+    description:
+      'Apenas usuários com token jwt e cargos "admin" podem utilizar este endpoint',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Nome do professor',
+          example: 'Marcos Silva',
+        },
+        cpf: {
+          type: 'string',
+          description: 'CPF do professor (apenas números)',
+          example: '12345678910',
+        },
+        email: {
+          type: 'string',
+          description: 'Email do professor',
+          example: 'marcossilva@gmail.com',
+        },
+        hourPrice: {
+          type: 'number',
+          description: 'Valor da hora/aula do professor',
+          example: '5.0',
+        },
+        description: {
+          type: 'string',
+          description: 'Descrição da modalidade',
+          example: `Faixa Preta 3º Dan. Com mais de 15 anos de experiência no judô.`,
+        },
+        modalities: {
+          type: 'array',
+          description: 'IDs das modalidades (ObjectId do MongoDB)',
+          items: {
+            type: 'string',
+            example: '64f1b2a3c4d5e6f7890abc12',
+          },
+        },
+        image: {
+          type: 'string',
+          format: 'binary',
+          description: 'Imagem da modalidade (jpg, jpeg, png, gif)',
+        },
+      },
+    },
+  })
+  @ApiConsumes('multipart/form-data')
   @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Roles('admin')
   @Throttle({

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -209,6 +209,14 @@ export class TeachersController {
     };
   }
 
+  @UseGuards(AuthGuard('jwt'), RoleGuard)
+  @Roles('admin')
+  @Throttle({
+    default: {
+      limit: 10,
+      ttl: 60000,
+    },
+  })
   @UploadImage()
   @Patch(':id')
   public async update(

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -207,7 +207,7 @@ export class TeachersService {
           updateTeacher.cpf,
         );
 
-        updateTeacher.cpf = updateTeacher.cpf;
+        teacherUpdates.cpf = updateTeacher.cpf;
       },
       email: async () => {
         await this.validateFieldsService.validateEmail(
@@ -215,7 +215,7 @@ export class TeachersService {
           updateTeacher.email,
         );
 
-        updateTeacher.email = updateTeacher.email;
+        teacherUpdates.email = updateTeacher.email;
       },
       description: () =>
         (teacherUpdates.description =


### PR DESCRIPTION
## O que foi feito
Funcionalidade de edição de um professor. Para isso foi desenvolvido o seguinte endpoint:
- `PATCH api/v1/teachers/{id}`
- Realiza a busca do professor pelo `id` e permite a alteração parcial ou total dos seguintes campos:
     - `name`
     - `cpf`
     - `email`
     - `description`
     - `hourPrice`
     - `modalities`
     - `image`
- Recebe body do tipo `multipart/form-data`
- Upload de imagem (jpg, jpeg, png, gif)
- Apenas administradores autenticados com token JWT realizar essa ação
- Limite máximo de 10 requisições por minuto
- Documentação dos endpoints no Swagger
- Testes unitários nos casos de sucesso e falha

#### [Ticket Trello - Editar professor](https://trello.com/c/BVFILCi0/46-editar-professor)