### PR TITLE
Feat/inactive teacher

### DIFF
--- a/src/modules/admin/admin.controller.spec.ts
+++ b/src/modules/admin/admin.controller.spec.ts
@@ -178,7 +178,7 @@ describe('AdminController', () => {
 
     const result = await controller.reactivate(adminId);
 
-    expect(result).toEqual({ data: 'Admin successfully deactivated' });
+    expect(result).toEqual({ data: 'Admin successfully reactivate' });
     expect(adminService.setStatus).toHaveBeenCalledWith(adminId, status);
   });
 

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -197,7 +197,7 @@ export class AdminController {
     await this.adminService.setStatus(id, true);
 
     return {
-      data: 'Admin successfully deactivated',
+      data: 'Admin successfully reactivate',
     };
   }
 

--- a/src/modules/teachers/teachers.controller.spec.ts
+++ b/src/modules/teachers/teachers.controller.spec.ts
@@ -30,6 +30,9 @@ describe('TeachersController', () => {
             findByIdWithRole: jest.fn(),
             findAllWithRole: jest.fn(),
             update: jest.fn(),
+            deactivate: jest.fn(),
+            reactive: jest.fn(),
+            setStatus: jest.fn(),
           },
         },
         {
@@ -356,6 +359,57 @@ describe('TeachersController', () => {
     const invalidId = '1234';
 
     await expect(controller.update(invalidId)).rejects.toThrow(
+      new BadRequestException('Invalid id format'),
+    );
+    expect(teachersService.findById).toHaveBeenCalledTimes(0);
+  });
+
+  it('should deactivate teacher successfully', async () => {
+    const id = '60c72b2f9b1d8c001c8e4e1a';
+
+    teachersService.deactivate = jest.fn().mockImplementation(() => {});
+
+    const result = await controller.deactivate(id);
+
+    expect(result).toEqual({
+      data: 'Teacher successfully deactivate',
+    });
+  });
+
+  it('should throw BadRequestException for invalid ID format in deactivate', async () => {
+    const invalidId = '1234';
+
+    await expect(controller.deactivate(invalidId)).rejects.toThrow(
+      new BadRequestException('Invalid id format'),
+    );
+    expect(teachersService.findById).toHaveBeenCalledTimes(0);
+  });
+
+  it('should reactivate teacher successfully', async () => {
+    const id = '60c72b2f9b1d8c001c8e4e1a';
+
+    const teacher = {
+      status: true,
+    } as TeacherDocument;
+
+    teachersService.findById = jest.fn().mockResolvedValue(teacher);
+    teachersService.setStatus = jest.fn().mockImplementation(() => {});
+
+    const result = await controller.reactivate(id);
+
+    expect(result).toEqual({
+      data: 'Teacher successfully reactivate',
+    });
+    expect(teachersService.findById).toHaveBeenCalledWith(
+      new Types.ObjectId(id),
+      ['status'],
+    );
+  });
+
+  it('should throw BadRequestException for invalid ID format in reactivate', async () => {
+    const invalidId = '1234';
+
+    await expect(controller.reactivate(invalidId)).rejects.toThrow(
       new BadRequestException('Invalid id format'),
     );
     expect(teachersService.findById).toHaveBeenCalledTimes(0);

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -300,4 +300,19 @@ export class TeachersController {
       data: updatedTeacher,
     };
   }
+
+  @Patch('reactivate/:id')
+  public async reactivate(
+    @Param('id') id: string,
+  ): Promise<ApiResponse<string>> {
+    if (!Types.ObjectId.isValid(id)) {
+      throw new BadRequestException('Invalid id format');
+    }
+
+    await this.teachersService.setStatus(id, true);
+
+    return {
+      data: 'Teacher successfully reactivate',
+    };
+  }
 }

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -301,6 +301,14 @@ export class TeachersController {
     };
   }
 
+  @UseGuards(AuthGuard('jwt'), RoleGuard)
+  @Roles('admin')
+  @Throttle({
+    default: {
+      limit: 10,
+      ttl: 60000,
+    },
+  })
   @Patch('deactivate/:id')
   public async deactivate(
     @Param('id') id: string,
@@ -316,6 +324,14 @@ export class TeachersController {
     };
   }
 
+  @UseGuards(AuthGuard('jwt'), RoleGuard)
+  @Roles('admin')
+  @Throttle({
+    default: {
+      limit: 10,
+      ttl: 60000,
+    },
+  })
   @Patch('reactivate/:id')
   public async reactivate(
     @Param('id') id: string,

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -301,6 +301,21 @@ export class TeachersController {
     };
   }
 
+  @Patch('deactivate/:id')
+  public async deactivate(
+    @Param('id') id: string,
+  ): Promise<ApiResponse<string>> {
+    if (!Types.ObjectId.isValid(id)) {
+      throw new BadRequestException('Invalid id format');
+    }
+
+    await this.teachersService.deactivate(id);
+
+    return {
+      data: 'Teacher successfully deactivate',
+    };
+  }
+
   @Patch('reactivate/:id')
   public async reactivate(
     @Param('id') id: string,
@@ -309,7 +324,12 @@ export class TeachersController {
       throw new BadRequestException('Invalid id format');
     }
 
-    await this.teachersService.setStatus(id, true);
+    const teacher = await this.teachersService.findById(
+      new Types.ObjectId(id),
+      ['status', 'save'],
+    );
+
+    await this.teachersService.setStatus(teacher, true);
 
     return {
       data: 'Teacher successfully reactivate',

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -301,6 +301,12 @@ export class TeachersController {
     };
   }
 
+  @ApiOperation({
+    summary: 'Desativar professor',
+    description: `Apenas usuários com token JWT e cargos "admin" podem utilizar este endpoint.
+    Ao ser desativado, não poderá ser vinculado a nenhuma turma, 
+    logo, deverá ser desvinculado de turmas ativas antes de ser inativado.`,
+  })
   @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Roles('admin')
   @Throttle({
@@ -324,6 +330,11 @@ export class TeachersController {
     };
   }
 
+  @ApiOperation({
+    summary: 'Reativar professor',
+    description:
+      'Apenas usuários com token jwt e cargos "admin" podem utilizar este endpoint',
+  })
   @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Roles('admin')
   @Throttle({

--- a/src/modules/teachers/teachers.controller.ts
+++ b/src/modules/teachers/teachers.controller.ts
@@ -353,7 +353,7 @@ export class TeachersController {
 
     const teacher = await this.teachersService.findById(
       new Types.ObjectId(id),
-      ['status', 'save'],
+      ['status'],
     );
 
     await this.teachersService.setStatus(teacher, true);

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -271,7 +271,6 @@ export class TeachersService {
     const teacher = await this.findById(new Types.ObjectId(id), [
       'id',
       'status',
-      'save',
     ]);
 
     const classes = await this.classesService.findByTeacher(teacher.id, ['id']);

--- a/src/modules/teachers/teachers.service.ts
+++ b/src/modules/teachers/teachers.service.ts
@@ -267,6 +267,17 @@ export class TeachersService {
     );
   }
 
+  public async setStatus(id: string, status: boolean): Promise<void> {
+    const teacher = await this.teachersModel.findById(id, { status: 1 }).exec();
+
+    if (!teacher) {
+      throw new NotFoundException('Teacher not found');
+    }
+
+    teacher.status = status;
+    await teacher.save();
+  }
+
   private hoursToHHMM(hours: number): string {
     const hour = Math.floor(hours);
     const minute = Math.round((hours - hour) * 60);


### PR DESCRIPTION
## O que foi feito
Funcionalidades de inativar e reativar professor. Para isso foi desenvolvido os seguinte endpoints:
- `PATCH api/v1/teachers/deactivate/{id}`: desativar professor
- `PATCH api/v1/teachers/reactive/{id}`: reativar professor
- Ao desativar um professor, ele não poderá mais ser vinculado a novas turmas, por isso é verificado se ele não possui nenhum relacionamento ativo antes da desativação
- Ao reativar um professor, ele volta a estar disponível para vinculação em turmas
- Apenas administradores autenticados com token JWT realizar essa ação
- Limite máximo de 10 requisições por minuto
- Documentação dos endpoints no Swagger
- Testes unitários nos casos de sucesso e falha

[Ticket Trello - Inativar e reativar professor](https://trello.com/c/EHLE2Zlm/47-inativar-e-reativar-professor)